### PR TITLE
Add PostCSS config to enable Tailwind styles

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};


### PR DESCRIPTION
## Summary
- configure PostCSS with TailwindCSS and autoprefixer so styles compile correctly

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_b_689181cbe1fc832c8964e65d1c337e89